### PR TITLE
add  $apiversion to uri

### DIFF
--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupAutopilotDeploymentProfileAssignment.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupAutopilotDeploymentProfileAssignment.ps1
@@ -1,4 +1,4 @@
-﻿function Invoke-IntuneBackupAutopilotDeploymentProfileAssignment {
+function Invoke-IntuneBackupAutopilotDeploymentProfileAssignment {
     <#
     .SYNOPSIS
     Backup Intune Autopilot Deployment Profile Assignments
@@ -24,7 +24,7 @@
     )
 
     # Get all assignments from all policies
-    $winAutopilotDeploymentProfiles = Invoke-MgGraphRequest -Uri "deviceManagement/windowsAutopilotDeploymentProfiles" | Get-MGGraphAllPages
+    $winAutopilotDeploymentProfiles = Invoke-MgGraphRequest -Uri "$apiversion/deviceManagement/windowsAutopilotDeploymentProfiles" | Get-MGGraphAllPages
 
 	if ($winAutopilotDeploymentProfiles.value -ne "") {
 
@@ -34,7 +34,7 @@
 		}
 	
 		foreach ($winAutopilotDeploymentProfile in $winAutopilotDeploymentProfiles) {
-			$assignments = Invoke-MgGraphRequest -Uri "deviceManagement/windowsAutopilotDeploymentProfiles/$($winAutopilotDeploymentProfile.id)/assignments" | Get-MGGraphAllPages
+			$assignments = Invoke-MgGraphRequest -Uri "$apiversion/deviceManagement/windowsAutopilotDeploymentProfiles/$($winAutopilotDeploymentProfile.id)/assignments" | Get-MGGraphAllPages
 			
 			if ($assignments) {
 				$fileName = ($winAutopilotDeploymentProfile.displayName).Split([IO.Path]::GetInvalidFileNameChars()) -join '_'


### PR DESCRIPTION
Solved this error when running backup:
GET https://graph.microsoft.com/deviceManagement/windowsAutopilotDeploymentProfiles/794012df-c9e9-4968-9d6b-d673aa43870a/assignments HTTP/1.1 404 Not Found Date: Wed,  
     | 22 Jan 2025 19:17:04 GMT Transfer-Encoding: chunked Connection: keep-alive Vary: Accept-Encoding Strict-Transport-Security: max-age=31536000 request-id:
     | 65d4361d-c018-44a0-ada5-52fa16df9939 client-request-id: 09e5c6f7-b004-4d04-8dae-bd636783b968 x-ms-ags-diagnostic: {"ServerInfo":{"DataCenter":"Norway
     | East","Slice":"E","Ring":"2","ScaleUnit":"002","RoleInstance":"OS2PEPF000003D9"}} X-Cache: CONFIG_NOCACHE Content-Type: application/json Content-Encoding: gzip         
     | {"error":{"code":"ResourceNotFound","message":"Invalid version:
     | devicemanagement","innerError":{"date":"2025-01-22T19:17:04","request-id":"65d4361d-c018-44a0-ada5-52fa16df9939","client-request-id":"09e5c6f7-b004-4d04-8dae-bd636783b968"}}}
Backup